### PR TITLE
Dockerfile improvements:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,24 @@
-FROM ubuntu:16.04
+FROM	ubuntu:latest
 
-RUN apt-get update -y && apt-get upgrade -y
+RUN	apt-get update -y \
+	&& apt-get install -y \
+	git \
+	make \
+	autoconf \
+	automake \
+	libtool \
+	bison \
+	flex \
+	g++ \
+	ncurses-dev \
+	&& git clone https://github.com/machinezone/tcpkali.git \
+	&& cd tcpkali \
+	&& test -f configure || autoreconf -iv \
+	&& ./configure \
+	&& make \
+	&& make install \
+	&& rm -rf /tcpkali \
+	&& apt-get remove -y git make autoconf automake ncurses-dev \
+	&& apt-get autoremove -y
 
-# tcpkali
-RUN apt-get install -y git \
-			make \
-			autoconf \
-			automake \
-			libtool \
-			bison \
-			flex \
-			g++ \
-			ncurses-dev
-
-RUN git clone https://github.com/machinezone/tcpkali.git
-WORKDIR "/tcpkali"
-RUN test -f configure || autoreconf -iv
-RUN ./configure
-RUN make
-RUN make install
+ENTRYPOINT	["tcpkali"]


### PR DESCRIPTION
- Followed advice from [dockerfile best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)
 including: `minimise number of layers` and `Sort multi-line arguments.`
- Updated to latest ubuntu image
- removed `apt-get upgrade` as ["_as many of the “essential” packages from the base images won’t upgrade inside an unprivileged container._"](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run)

- Passed through [dockfmt](https://github.com/jessfraz/dockfmt)

- Added ENTRYPOINT to allow easy running of `tcpkali`